### PR TITLE
Update AWS Lambda node runtime version

### DIFF
--- a/amplify/backend/auth/cognito704b3e59/cognito704b3e59-cloudformation-template.yml
+++ b/amplify/backend/auth/cognito704b3e59/cognito704b3e59-cloudformation-template.yml
@@ -263,7 +263,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole


### PR DESCRIPTION
Quotes from AWS's email about the deprecation of the Node 6.10 runtime:

The Node Foundation has previously published that node.js 6.x "Boron"
will be declared End-of-Life (EOL) on April 2019 [1], and will stop
receiving bug fixes, security updates, or performance improvements.

Invokes for functions configured to run on node.js 6.10 will continue to
work normally, however the ability to create new Lambda functions
configured to use the node.js 6.10 runtime will be disabled on April 30
2019. Code updates to existing functions using node.js 6.10 will be
disabled 30 days later on May 30 2019.

We encourage you to update your node.js 6.10 Lambda functions and
applications published to the AWS Serverless Application Repository to a
newer version of the Node runtime (node.js 8.10) so that you continue to
benefit from important security, performance, and functionality
enhancements offered by more recent releases.

[1] Node Foundation’s announcement of EOL: https://nodejs.org/en/blog/release/v6.9.0/