### PR TITLE
Fix yarn.lock problem related to the package @babel/runtime

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -801,7 +801,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.4.4":
+"@babel/runtime@^7.4.3", "@babel/runtime@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
   integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==


### PR DESCRIPTION
- @TadjM created a merge conflict with this file
- I tried to resolve using GitHub's online merge conflict tool
- Proper fix required specifying both versions of the package