### PR TITLE
Add DatasetList component, place it in SidePane

### DIFF
--- a/src/components/DatasetList.js
+++ b/src/components/DatasetList.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Accordion, Button, Card } from 'react-bootstrap'
+
+const datasets = [
+  {
+    name: 'Dataset-1',
+    description: 'A short description of dataset-1',
+  },
+  {
+    name: 'Dataset-2',
+    description: 'A short description of dataset-2',
+  },
+  {
+    name: 'Dataset-3',
+    description: 'A short description of dataset-3',
+  },
+  {
+    name: 'Dataset-4',
+    description: 'A short description of dataset-4',
+  },
+]
+
+const DatasetList = () => (
+  <Accordion defaultActiveKey='0'>
+    {datasets.map(({ name, description }, index) => (
+      <Card key={index}>
+        <Card.Header>
+          <Accordion.Toggle
+            as={Button}
+            variant='link'
+            eventKey={'' + index}
+            className='stretched-link'
+          >
+            {name}
+          </Accordion.Toggle>
+        </Card.Header>
+        <Accordion.Collapse eventKey={'' + index}>
+          <Card.Body>{description}</Card.Body>
+        </Accordion.Collapse>
+      </Card>
+    ))}
+  </Accordion>
+)
+
+export default DatasetList

--- a/src/components/SidePane.js
+++ b/src/components/SidePane.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { Tabs, Tab } from 'react-bootstrap'
 
+import DatasetList from './DatasetList'
 import styles from './SidePane.css'
 
 class SidePane extends Component {
@@ -35,17 +36,7 @@ class SidePane extends Component {
           arcu vel gravida ultricies.
         </Tab>
         <Tab eventKey='list' title='List'>
-          Nulla urna sapien, hendrerit sit amet risus in, facilisis pharetra
-          erat. Suspendisse imperdiet dui vel pharetra facilisis. Mauris
-          malesuada, quam sed vehicula accumsan, arcu justo congue dolor, non
-          tempus eros augue eu arcu. Sed quis massa at metus consequat feugiat
-          eu vel lorem. Proin imperdiet libero sed ipsum finibus, in congue
-          neque fringilla. Class aptent taciti sociosqu ad litora torquent per
-          conubia nostra, per inceptos himenaeos. Nam eu erat sed mi tincidunt
-          rhoncus. Vivamus facilisis, erat eget iaculis congue, est odio viverra
-          sapien, vel feugiat est risus ac mauris. Nunc eu mauris imperdiet nibh
-          malesuada sagittis. Duis luctus vehicula nisi. Sed a est efficitur,
-          imperdiet mauris et, tempor lacus.
+          <DatasetList />
         </Tab>
         <Tab eventKey='discuss' title='Discuss'>
           Vestibulum semper nec sem eget scelerisque. Morbi sem lorem, dictum


### PR DESCRIPTION
- DatasetList component uses hardcoded stubs of dataset names and
descriptions
- Will eventually move dataset metadata to parent React component
- Ultimately the dataset metadata should be queried from backend API because our app should allow for admins to easily add news datasets