### PR TITLE
Fix site title on non index routes

### DIFF
--- a/src/pages/app.js
+++ b/src/pages/app.js
@@ -9,8 +9,8 @@ import Login from '../components/Login'
 import SignUp from '../components/SignUp'
 import PrivateRoute from '../components/PrivateRoute'
 
-const App = props => (
-  <Layout siteTitle={props.data.site.siteMetadata.title}>
+const App = ({ data }) => (
+  <Layout siteTitle={data.site.siteMetadata.title}>
     <Router>
       <PrivateRoute path='/app/home' component={Home} />
       <PrivateRoute path='/app/profile' component={Details} />

--- a/src/pages/app.js
+++ b/src/pages/app.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { graphql } from 'gatsby'
 import { Router } from '@reach/router'
 
 import Layout from '../components/layout'
@@ -8,8 +9,8 @@ import Login from '../components/Login'
 import SignUp from '../components/SignUp'
 import PrivateRoute from '../components/PrivateRoute'
 
-const App = () => (
-  <Layout>
+const App = props => (
+  <Layout siteTitle={props.data.site.siteMetadata.title}>
     <Router>
       <PrivateRoute path='/app/home' component={Home} />
       <PrivateRoute path='/app/profile' component={Details} />
@@ -18,5 +19,13 @@ const App = () => (
     </Router>
   </Layout>
 )
+
+export const query = graphql`
+  query AppQuery {
+    site {
+      ...SiteTitle
+    }
+  }
+`
 
 export default App

--- a/src/pages/app.js
+++ b/src/pages/app.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Router } from '@reach/router'
+
 import Layout from '../components/layout'
 import Details from '../components/Details'
 import Home from '../components/Home'
-import Map from '../components/Map'
 import Login from '../components/Login'
 import SignUp from '../components/SignUp'
 import PrivateRoute from '../components/PrivateRoute'
@@ -13,7 +13,6 @@ const App = () => (
     <Router>
       <PrivateRoute path='/app/home' component={Home} />
       <PrivateRoute path='/app/profile' component={Details} />
-      <PrivateRoute path='/app/map' component={Map} />
       <Login path='/app/login' />
       <SignUp path='/app/signup' />
     </Router>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -88,11 +88,9 @@ class IndexPage extends Component {
 }
 
 export const query = graphql`
-  query SiteTitleQuery {
+  query IndexQuery {
     site {
-      siteMetadata {
-        title
-      }
+      ...SiteTitle
     }
   }
 `

--- a/src/queries/fragments.js
+++ b/src/queries/fragments.js
@@ -1,0 +1,9 @@
+import { graphql } from 'gatsby'
+
+export const variableName = graphql`
+  fragment SiteTitle on Site {
+    siteMetadata {
+      title
+    }
+  }
+`


### PR DESCRIPTION
- Could add whole siteTitle GraphQL query to the app component because query names must be unique
- Used the following guide to reuse queries as fragments
- https://www.gatsbycentral.com/reusable-graphql-queries-in-gatsby

Fixed #87 