### PR TITLE
Fix gatsby leaflet build error

### DIFF
--- a/src/components/GeocodeForm.js
+++ b/src/components/GeocodeForm.js
@@ -1,75 +1,19 @@
-import React, { Component } from 'react'
+import React from 'react'
 
-class GeocodeForm extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      error: null,
-      isLoaded: false,
-      location: [],
-      address: '',
-    }
-    this.handleSubmit = this.handleSubmit.bind(this)
-    this.handleChange = this.handleChange.bind(this)
-  }
-  state = {
-    lat: 51.505,
-    lng: -0.09,
-    zoom: 13,
-  }
-
-  geocodeAddress (address) {
-    fetch(
-      `https://maps.googleapis.com/maps/api/geocode/json?address=${address}&key=${
-        process.env.GATSBY_GMAPS_API_KEY
-      }`
-    )
-      .then(res => res.json())
-      .then(
-        result => {
-          this.setState({
-            isLoaded: true,
-            location: result.results[0].geometry.location,
-            address,
-          })
-        },
-        // Note: it's important to handle errors here
-        // instead of a catch() block so that we don't swallow
-        // exceptions from actual bugs in components.
-        error => {
-          this.setState({
-            isLoaded: true,
-            error,
-          })
-        }
-      )
-  }
-
-  handleChange (event) {
-    this.setState({ address: event.target.value })
-  }
-
-  handleSubmit (event) {
-    event.preventDefault()
-    this.geocodeAddress(this.state.address)
-  }
-
-  render () {
-    const { location } = this.state
-    return (
-      <div>
-        <p>Enter address:</p>
-        <form onSubmit={this.handleSubmit}>
-          <input type='text' name='address' onChange={this.handleChange} />
-          <button type='submit'>Submit</button>
-        </form>
-        <span>
-          location:{' '}
-          {location ? `lat : ${location.lat} lng : ${location.lng}` : ''}
-        </span>
-      </div>
-    )
-  }
-}
+const GeocodeForm = ({ handleChange, handleSubmit, outputLocation }) => (
+  <div>
+    <h4>Enter address:</h4>
+    <form onSubmit={handleSubmit}>
+      <input type='text' name='address' onChange={handleChange} />
+      <button type='submit'>Submit</button>
+    </form>
+    <h4>Output:</h4>
+    <p>
+      {outputLocation && (
+        <span>{`lat: ${outputLocation.lat}, lng: ${outputLocation.lng}`}</span>
+      )}
+    </p>
+  </div>
+)
 
 export default GeocodeForm

--- a/src/components/GeocodeForm.js
+++ b/src/components/GeocodeForm.js
@@ -1,0 +1,75 @@
+import React, { Component } from 'react'
+
+class GeocodeForm extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      error: null,
+      isLoaded: false,
+      location: [],
+      address: '',
+    }
+    this.handleSubmit = this.handleSubmit.bind(this)
+    this.handleChange = this.handleChange.bind(this)
+  }
+  state = {
+    lat: 51.505,
+    lng: -0.09,
+    zoom: 13,
+  }
+
+  geocodeAddress (address) {
+    fetch(
+      `https://maps.googleapis.com/maps/api/geocode/json?address=${address}&key=${
+        process.env.GATSBY_GMAPS_API_KEY
+      }`
+    )
+      .then(res => res.json())
+      .then(
+        result => {
+          this.setState({
+            isLoaded: true,
+            location: result.results[0].geometry.location,
+            address,
+          })
+        },
+        // Note: it's important to handle errors here
+        // instead of a catch() block so that we don't swallow
+        // exceptions from actual bugs in components.
+        error => {
+          this.setState({
+            isLoaded: true,
+            error,
+          })
+        }
+      )
+  }
+
+  handleChange (event) {
+    this.setState({ address: event.target.value })
+  }
+
+  handleSubmit (event) {
+    event.preventDefault()
+    this.geocodeAddress(this.state.address)
+  }
+
+  render () {
+    const { location } = this.state
+    return (
+      <div>
+        <p>Enter address:</p>
+        <form onSubmit={this.handleSubmit}>
+          <input type='text' name='address' onChange={this.handleChange} />
+          <button type='submit'>Submit</button>
+        </form>
+        <span>
+          location:{' '}
+          {location ? `lat : ${location.lat} lng : ${location.lng}` : ''}
+        </span>
+      </div>
+    )
+  }
+}
+
+export default GeocodeForm

--- a/src/components/LeafletMap.js
+++ b/src/components/LeafletMap.js
@@ -19,13 +19,13 @@ if (process.env.GATSBY_CLIENT) {
   })
 }
 
-const LeafletMap = ({ data, children }) => (
+const LeafletMap = ({ data, center, zoom, children }) => (
   <>
     {process.env.GATSBY_CLIENT && (
       <Map
         style={{ height: '800px', width: '800px' }}
-        center={[51.505, -0.09]}
-        zoom={13}
+        center={center}
+        zoom={zoom}
       >
         <TileLayer
           attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'

--- a/src/components/LeafletMap.js
+++ b/src/components/LeafletMap.js
@@ -1,0 +1,40 @@
+import React from 'react'
+
+let RL = false
+let Map = false
+let TileLayer = false
+let L = false
+if (process.env.GATSBY_CLIENT) {
+  console.log(`env: ${process.env.GATSBY_CLIENT}`)
+  RL = require('react-leaflet')
+  L = require('leaflet')
+  require('leaflet/dist/leaflet.css')
+  Map = RL.Map
+  TileLayer = RL.TileLayer
+  delete L.Icon.Default.prototype._getIconUrl
+  L.Icon.Default.mergeOptions({
+    iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
+    iconUrl: require('leaflet/dist/images/marker-icon.png'),
+    shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
+  })
+}
+
+const LeafletMap = ({ data, children }) => (
+  <>
+    {process.env.GATSBY_CLIENT && (
+      <Map
+        style={{ height: '800px', width: '800px' }}
+        center={[51.505, -0.09]}
+        zoom={13}
+      >
+        <TileLayer
+          attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+        />
+        {children}
+      </Map>
+    )}
+  </>
+)
+
+export default LeafletMap

--- a/src/pages/cultural_institution_page.js
+++ b/src/pages/cultural_institution_page.js
@@ -1,64 +1,37 @@
-import React from 'react'
-import { Map, TileLayer, Marker, Popup } from 'react-leaflet'
-import 'leaflet/dist/leaflet.css'
-import L from 'leaflet'
+import React, { Component } from 'react'
+import { graphql } from 'gatsby'
+
 import Layout from '../components/layout'
-import { StaticQuery, graphql } from 'gatsby'
+import LeafletMap from '../components/LeafletMap'
 
-const CulturalInstitutionsPage = () => (
-  <Layout>
-    Cultural Institutions Data
-    <CulturalInstitution />
-  </Layout>
-)
+let RL = false
+let Marker = false
+let Popup = false
+if (process.env.GATSBY_CLIENT) {
+  console.log(`env: ${process.env.GATSBY_CLIENT}`)
+  RL = require('react-leaflet')
+  Marker = RL.Marker
+  Popup = RL.Popup
+}
 
-delete L.Icon.Default.prototype._getIconUrl
-
-L.Icon.Default.mergeOptions({
-  iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
-  iconUrl: require('leaflet/dist/images/marker-icon.png'),
-  shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
-})
-
-class CulturalInstitution extends React.Component {
+class CulturalInstitutionsPage extends Component {
   state = {
-    lat: 40.7128,
-    lng: -73.9352,
     zoom: 12,
+    center: {
+      lat: 40.7128,
+      lng: -73.9352,
+    },
   }
-
-  // const position = [this.state.lat, this.state.lng]
 
   render () {
     return (
-      <StaticQuery
-        query={graphql`
-          query {
-            allCulturalInstitutionsJson {
-              nodes {
-                Organization_Name
-                Preferred_Address_Line_1
-                Borough
-                Community_Board
-                position {
-                  lat
-                  lng
-                }
-              }
-            }
-          }
-        `}
-        render={data => (
-          <Map
-            style={{ height: '100%', width: '66%' }}
-            center={{ lat: 40.7128, lng: -73.9352 }}
-            zoom={this.state.zoom}
-          >
-            <TileLayer
-              attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-              url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
-            />
-            {data.allCulturalInstitutionsJson.nodes.map((node, index) => (
+      <Layout
+        siteTitle={this.props.data.site.siteMetadata.title}
+        subpageTitle='Cultural Institutions'
+      >
+        <LeafletMap center={this.state.center} zoom={this.state.zoom}>
+          {this.props.data.allCulturalInstitutionsJson.nodes.map(
+            (node, index) => (
               <Marker key={index} position={node.position}>
                 <Popup>
                   <strong>{node.Organization_Name}</strong>
@@ -66,12 +39,32 @@ class CulturalInstitution extends React.Component {
                   {node.Preferred_Address_Line_1}
                 </Popup>
               </Marker>
-            ))}
-          </Map>
-        )}
-      />
+            )
+          )}
+        </LeafletMap>
+      </Layout>
     )
   }
 }
+
+export const query = graphql`
+  query CulturalInstitutionsQuery {
+    site {
+      ...SiteTitle
+    }
+    allCulturalInstitutionsJson {
+      nodes {
+        Organization_Name
+        Preferred_Address_Line_1
+        Borough
+        Community_Board
+        position {
+          lat
+          lng
+        }
+      }
+    }
+  }
+`
 
 export default CulturalInstitutionsPage

--- a/src/pages/geocode_experiment.js
+++ b/src/pages/geocode_experiment.js
@@ -11,6 +11,11 @@ class GeocodeExperimentPage extends Component {
     this.state = {
       outputLocation: false,
       address: '',
+      zoom: 12,
+      center: {
+        lat: 40.7128,
+        lng: -73.9352,
+      },
     }
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleChange = this.handleChange.bind(this)
@@ -61,7 +66,7 @@ class GeocodeExperimentPage extends Component {
           handleSubmit={this.handleSubmit}
           outputLocation={this.state.outputLocation}
         />
-        <LeafletMap />
+        <LeafletMap center={this.state.center} zoom={this.state.zoom} />
       </Layout>
     )
   }

--- a/src/pages/geocode_experiment.js
+++ b/src/pages/geocode_experiment.js
@@ -2,85 +2,14 @@ import React from 'react'
 
 import Layout from '../components/layout'
 import LeafletMap from '../components/LeafletMap'
+import GeocodeForm from '../components/GeocodeForm'
 
 const GeocodeExperimentPage = () => (
   <Layout>
     Geocode Experiment
-    <Geocode />
+    <GeocodeForm />
     <LeafletMap />
   </Layout>
 )
-
-class Geocode extends React.Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      error: null,
-      isLoaded: false,
-      location: [],
-      address: '',
-    }
-    this.handleSubmit = this.handleSubmit.bind(this)
-    this.handleChange = this.handleChange.bind(this)
-  }
-  state = {
-    lat: 51.505,
-    lng: -0.09,
-    zoom: 13,
-  }
-
-  geocodeAddress (address) {
-    fetch(
-      `https://maps.googleapis.com/maps/api/geocode/json?address=${address}&key=${
-        process.env.GATSBY_GMAPS_API_KEY
-      }`
-    )
-      .then(res => res.json())
-      .then(
-        result => {
-          this.setState({
-            isLoaded: true,
-            location: result.results[0].geometry.location,
-            address,
-          })
-        },
-        // Note: it's important to handle errors here
-        // instead of a catch() block so that we don't swallow
-        // exceptions from actual bugs in components.
-        error => {
-          this.setState({
-            isLoaded: true,
-            error,
-          })
-        }
-      )
-  }
-
-  handleChange (event) {
-    this.setState({ address: event.target.value })
-  }
-
-  handleSubmit (event) {
-    event.preventDefault()
-    this.geocodeAddress(this.state.address)
-  }
-
-  render () {
-    const { location } = this.state
-    return (
-      <div>
-        <p>Enter address:</p>
-        <form onSubmit={this.handleSubmit}>
-          <input type='text' name='address' onChange={this.handleChange} />
-          <button type='submit'>Submit</button>
-        </form>
-        <span>
-          location:{' '}
-          {location ? `lat : ${location.lat} lng : ${location.lng}` : ''}
-        </span>
-      </div>
-    )
-  }
-}
 
 export default GeocodeExperimentPage

--- a/src/pages/geocode_experiment.js
+++ b/src/pages/geocode_experiment.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { graphql } from 'gatsby'
 
 import Layout from '../components/layout'
 import LeafletMap from '../components/LeafletMap'
@@ -51,7 +52,10 @@ class GeocodeExperimentPage extends Component {
 
   render () {
     return (
-      <Layout subpageTitle='Geocode Experiment'>
+      <Layout
+        siteTitle={this.props.data.site.siteMetadata.title}
+        subpageTitle='Geocode Experiment'
+      >
         <GeocodeForm
           handleChange={this.handleChange}
           handleSubmit={this.handleSubmit}
@@ -62,5 +66,13 @@ class GeocodeExperimentPage extends Component {
     )
   }
 }
+
+export const query = graphql`
+  query GeocodeExperimentQuery {
+    site {
+      ...SiteTitle
+    }
+  }
+`
 
 export default GeocodeExperimentPage

--- a/src/pages/geocode_experiment.js
+++ b/src/pages/geocode_experiment.js
@@ -1,8 +1,7 @@
 import React from 'react'
-import { Map, TileLayer } from 'react-leaflet'
-import 'leaflet/dist/leaflet.css'
 
 import Layout from '../components/layout'
+import LeafletMap from '../components/LeafletMap'
 
 const GeocodeExperimentPage = () => (
   <Layout>
@@ -81,34 +80,6 @@ class Geocode extends React.Component {
         </span>
       </div>
     )
-  }
-}
-
-class LeafletMap extends React.Component {
-  state = {
-    lat: 51.505,
-    lng: -0.09,
-    zoom: 13,
-  }
-
-  render () {
-    if (typeof window !== 'undefined') {
-      const position = [this.state.lat, this.state.lng]
-      return (
-        <Map
-          style={{ height: '800px', width: '800px' }}
-          center={position}
-          zoom={this.state.zoom}
-        >
-          <TileLayer
-            attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-            url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
-          />
-        </Map>
-      )
-    } else {
-      return null
-    }
   }
 }
 

--- a/src/pages/geocode_experiment.js
+++ b/src/pages/geocode_experiment.js
@@ -1,15 +1,66 @@
-import React from 'react'
+import React, { Component } from 'react'
 
 import Layout from '../components/layout'
 import LeafletMap from '../components/LeafletMap'
 import GeocodeForm from '../components/GeocodeForm'
 
-const GeocodeExperimentPage = () => (
-  <Layout>
-    Geocode Experiment
-    <GeocodeForm />
-    <LeafletMap />
-  </Layout>
-)
+class GeocodeExperimentPage extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      outputLocation: false,
+      address: '',
+    }
+    this.handleSubmit = this.handleSubmit.bind(this)
+    this.handleChange = this.handleChange.bind(this)
+  }
+
+  handleChange (event) {
+    this.setState({ address: event.target.value })
+  }
+
+  handleSubmit (event) {
+    event.preventDefault()
+    this.geocodeAddress(this.state.address)
+  }
+
+  geocodeAddress (address) {
+    if (!address) return false
+    fetch(
+      `https://maps.googleapis.com/maps/api/geocode/json?address=${address}&key=${
+        process.env.GATSBY_GMAPS_API_KEY
+      }`
+    )
+      .then(res => res.json())
+      .then(
+        result => {
+          const outputLocation = result.results.length
+            ? result.results[0].geometry.location
+            : false
+          this.setState({
+            outputLocation,
+          })
+        },
+        error => {
+          this.setState({
+            outputLocation: false,
+          })
+        }
+      )
+  }
+
+  render () {
+    return (
+      <Layout subpageTitle='Geocode Experiment'>
+        <GeocodeForm
+          handleChange={this.handleChange}
+          handleSubmit={this.handleSubmit}
+          outputLocation={this.state.outputLocation}
+        />
+        <LeafletMap />
+      </Layout>
+    )
+  }
+}
 
 export default GeocodeExperimentPage


### PR DESCRIPTION
- Use `GATSBY_CLIENT` env variable to differentiate running the app and building it
- Check env variable before import/requiring `react-leaflet`
- By avoiding those imports/requires the build step completes successfully 

Fixed #77 